### PR TITLE
Remove redundant ?encoding in merge_query_string

### DIFF
--- a/src/gapi/gapiUtils.ml
+++ b/src/gapi/gapiUtils.ml
@@ -20,7 +20,7 @@ let etag_option etag =
       "" -> None
     | v -> Some v
 
-let merge_query_string ?(encoded = true) parameters url =
+let merge_query_string parameters url =
   let neturl = Neturl.parse_url url in
   let fields =
     try

--- a/src/gapi/gapiUtils.mli
+++ b/src/gapi/gapiUtils.mli
@@ -12,9 +12,7 @@ val is_weak_etag : string -> bool
 
 val etag_option : string -> string option
 
-val merge_query_string :
-  ?encoded:bool ->
-  (string * string) list -> string -> string
+val merge_query_string : (string * string) list -> string -> string
 
 val add_path_to_url :
   ?encoded:bool ->


### PR DESCRIPTION
Either this param is redundant or you've forgotten to pass it through.