### PR TITLE
Added options to set proxy and disable verification of SSL certificate

### DIFF
--- a/src/gapi/gapiConfig.ml
+++ b/src/gapi/gapiConfig.ml
@@ -68,6 +68,8 @@ type t = {
   low_speed_limit : int;
   low_speed_time : int;
   curl_no_signal : bool;
+  proxy: string option;
+  ssl_verifypeer: bool;
 }
 
 let application_name = {
@@ -118,6 +120,14 @@ let curl_no_signal = {
   GapiLens.get = (fun x -> x.curl_no_signal);
   GapiLens.set = (fun v x -> { x with curl_no_signal = v })
 }
+let proxy = {
+  GapiLens.get = (fun x -> x.proxy);
+  GapiLens.set = (fun v x -> { x with proxy = v })
+}
+let ssl_verifypeer = {
+  GapiLens.get = (fun x -> x.ssl_verifypeer);
+  GapiLens.set = (fun v x -> { x with ssl_verifypeer = v })
+}
 
 let default = {
   application_name = "gapi-ocaml";
@@ -132,6 +142,8 @@ let default = {
   low_speed_limit = 0;
   low_speed_time = 0;
   curl_no_signal = true;
+  proxy = None;
+  ssl_verifypeer = true;
 }
 
 let default_debug = {
@@ -147,5 +159,7 @@ let default_debug = {
   low_speed_limit = 0;
   low_speed_time = 0;
   curl_no_signal = true;
+  proxy = None;
+  ssl_verifypeer = true;
 }
 

--- a/src/gapi/gapiConfig.mli
+++ b/src/gapi/gapiConfig.mli
@@ -95,6 +95,11 @@ type t = {
   (** It contains the time in number seconds that the transfer speed should be below the [low_speed_limit] for the library to consider it too slow and abort. Defaults to 0 (disabled). *)
   curl_no_signal : bool;
   (** If [true], libcurl will not use any functions that install signal handlers or any functions that cause signals to be sent to the process. This option is here to allow multi-threaded unix applications to still set/use all timeout options etc, without risking getting signals. Defaults to [true] *)
+  proxy: string option;
+  (** Set the Iproxy\ to use . The parameter should be tring holding the host name or dotted numerical IP address. A numerical IPv6 address must be written within [brackets].
+    To specify port number in this string, append :[port] to the end of the host name. **)
+  ssl_verifypeer: bool;
+  (** When  ssl_verifypeer is enabled, and the verification fails to prove that the certificate is authentic, the connection fails.  When the option is disabled, the peer certificate verification succeeds regardless. **)
 }
 
 val application_name : (t, string) GapiLens.t

--- a/src/gapi/gapiConversation.ml
+++ b/src/gapi/gapiConversation.ml
@@ -267,6 +267,8 @@ let with_session
   let low_speed_limit = config.GapiConfig.low_speed_limit in
   let low_speed_time = config.GapiConfig.low_speed_time in
   let no_signal = config.GapiConfig.curl_no_signal in
+  let proxy = config.GapiConfig.proxy in
+  let ssl_verifypeer = config.GapiConfig.ssl_verifypeer in
   let curl_session =
     GapiCurl.init
       ?debug_function
@@ -278,6 +280,8 @@ let with_session
       ~low_speed_limit
       ~low_speed_time
       ~no_signal
+      ?proxy
+      ~ssl_verifypeer
       curl_state in
   let cleanup () = ignore (GapiCurl.cleanup curl_session) in
   let session =

--- a/src/gapi/gapiCurl.ml
+++ b/src/gapi/gapiCurl.ml
@@ -52,6 +52,8 @@ let init
       ?(low_speed_limit = 0)
       ?(low_speed_time = 0)
       ?(no_signal = true)
+      ?proxy
+      ?(ssl_verifypeer = true)
       ?options
       (state : [`Initialized] t) : [`Created] t =
   let error_buffer = ref "" in
@@ -94,6 +96,8 @@ let init
   Curl.set_nosignal curl no_signal;
   Curl.set_errorbuffer curl error_buffer;
   Curl.set_followlocation curl follow_location;
+  Option.may (fun proxy -> Curl.set_proxy curl proxy) proxy;
+  Curl.set_sslverifypeer curl ssl_verifypeer;
   Created { curl;
             error_buffer;
             disposed = false }

--- a/src/gapi/gapiCurl.mli
+++ b/src/gapi/gapiCurl.mli
@@ -22,6 +22,8 @@ val init :
   ?low_speed_limit:int ->
   ?low_speed_time:int ->
   ?no_signal:bool ->
+  ?proxy:string ->
+  ?ssl_verifypeer:bool ->
   ?options:Curl.curlOption list ->
   [ `Initialized ] t ->
   [ `Created ] t


### PR DESCRIPTION
Motivation for this change is to simplify routing of traffic through https://github.com/mitmproxy/mitmproxy which is way better debug option then dumping data from libcurl.