### PR TITLE
Convince curl do not use chunked encoding

### DIFF
--- a/src/gapi/gapiConversation.ml
+++ b/src/gapi/gapiConversation.ml
@@ -203,7 +203,13 @@ let request
     | Some (GapiCore.PostData.Fields key_value_list) ->
       GapiCurl.set_postfields key_value_list session.Session.curl
     | Some (GapiCore.PostData.Body (body, _)) ->
-      GapiCurl.set_httpbody body session.Session.curl
+      GapiCurl.set_httpbody body session.Session.curl;
+      (
+        match media_download,http_method with
+          None, GapiCore.HttpMethod.PUT ->
+          GapiCurl.set_post true session.Session.curl;
+        | _ -> ()
+      )
     | None ->
       match http_method with
       | GapiCore.HttpMethod.POST ->


### PR DESCRIPTION
This change allows to trick libcurl not use chunked transfer encoding and add Content-Length when using the PUT request. 
Basically when doing something like:
```
GapiService.service_request_with_data GapiRequest.Update
    (fun body -> GapiCore.PostData.Body (GapiCore.PostData.String body,  "multipart/related; boundary=...")
    ~version ?etag entry url
    (fun pipe _ -> parse pipe)
    session
```
Without changes this will lead to curl produce the following header:
````
Host:               sites.google.com
User-Agent:         gapi-ocaml gapi-ocaml/0.3.6/Unix
Accept:             */*
Accept-Encoding:    deflate
Transfer-Encoding:  chunked
Content-Type:       multipart/related; boundary=END_OF_PART
Authorization:      Bearer ...
GData-Version:      1.4
If-Match:           "WSl7JmA4"
````
And with changes:
````
Host:               sites.google.com
User-Agent:         gapi-ocaml gapi-ocaml/0.3.6/Unix
Accept:             */*
Accept-Encoding:    deflate
Transfer-Encoding:  chunked
Content-Type:       multipart/related; boundary=END_OF_PART
Authorization:      Bearer ...
GData-Version:      1.4
If-Match:           "WSl7JmA4"
````
And google API didn't like MIME/multipart combined with Chunked encdoing (and no Content-Length).
