### PR TITLE
Added option to control whitespace stripping when parsing XML/XHTML

### DIFF
--- a/src/gdata/gdataUtils.ml
+++ b/src/gdata/gdataUtils.ml
@@ -97,8 +97,8 @@ let data_to_xml_string ?(buffer_size = 512) tree =
   Bytes.fill result 38 1 ' ';
   Bytes.to_string result
 
-let parse_xml next_byte parse_tree =
-  let input = Xmlm.make_input ~strip:true (`Fun next_byte) in 
+let parse_xml ?(strip=true) next_byte parse_tree =
+  let input = Xmlm.make_input ~strip (`Fun next_byte) in
   let el tag children =
     let ((namespace, name), attribute_list) = tag in
     let attrs = List.map

--- a/src/gdata/gdataUtils.mli
+++ b/src/gdata/gdataUtils.mli
@@ -24,6 +24,7 @@ val data_to_xml_string :
   string
 
 val parse_xml :
+  ?strip:bool ->
   (unit -> int) ->
   (GdataCore.xml_data_model -> 'a) ->
   'a


### PR DESCRIPTION
This makes possible to parse XHTML while preserving white spaces inside the \<pre\> tag.