### PR TITLE
Clean up cleanup

### DIFF
--- a/src/gapi/gapiConversation.ml
+++ b/src/gapi/gapiConversation.ml
@@ -302,19 +302,11 @@ let with_curl
     config
     interact =
   let curl_state = GapiCurl.global_init () in
-  let cleanup () = ignore (GapiCurl.global_cleanup curl_state) in
-  try
-    let result =
-      with_session
-        ?auth_context
-        config
-        curl_state
-        interact in
-    cleanup ();
-    result
-  with e ->
-    cleanup ();
-    raise e
+  with_session
+    ?auth_context
+    config
+    curl_state
+    interact
 
 let read_all ?(auto_close = true) pipe =
   let result = GapiPipe.OcamlnetPipe.read_all pipe in

--- a/src/gapi/gapiConversation.ml
+++ b/src/gapi/gapiConversation.ml
@@ -286,7 +286,7 @@ let with_session
       ?proxy
       ~ssl_verifypeer
       curl_state in
-  let cleanup () = ignore (GapiCurl.cleanup curl_session) in
+  Gc.finalise (fun _ -> ignore (GapiCurl.cleanup curl_session)) curl_session;
   let session =
     { Session.curl = curl_session;
       config = config;
@@ -295,13 +295,7 @@ let with_session
       etag = ""
     }
   in
-  try
-    let result = interact session in
-    cleanup ();
-    result
-  with e ->
-    cleanup ();
-    raise e
+  interact session
 
 let with_curl
     ?auth_context

--- a/src/gapi/gapiCurl.ml
+++ b/src/gapi/gapiCurl.ml
@@ -42,8 +42,11 @@ let reader ?(close_if_at_eof = fun () -> ()) netchannel bytes =
   (* TODO: remove when Curl.set_readfunction is modified in: int -> bytes *)
   Bytes.to_string result
 
-let global_init () : [`Initialized] t =
+let () =
   Curl.global_init Curl.CURLINIT_GLOBALALL;
+  at_exit (fun () -> Curl.global_cleanup ())
+
+let global_init () : [`Initialized] t =
   Initialized
 
 let init
@@ -272,11 +275,6 @@ let cleanup (state : [`Created] t) : [`Destroyed] t =
        Destroyed
     )
     state
-
-let global_cleanup
-      (_ : [`Initialized] t) : [`Uninitialized] t =
-  Curl.global_cleanup ();
-  Uninitialized
 
 let string_of_curl_info_type info_type =
   match info_type with

--- a/src/gapi/gapiCurl.mli
+++ b/src/gapi/gapiCurl.mli
@@ -66,7 +66,5 @@ val get_responsecode : [ `Created ] t -> int
 
 val cleanup : [ `Created ] t -> [ `Destroyed ] t
 
-val global_cleanup : [ `Initialized ] t -> [ `Uninitialized ] t
-
 val string_of_curl_info_type : Curl.curlDebugType -> string
 

--- a/src/test/testHelper.ml
+++ b/src/test/testHelper.ml
@@ -71,7 +71,6 @@ let do_request
       interact
       handle_exception =
   let state = GapiCurl.global_init () in
-  let cleanup () = ignore (GapiCurl.global_cleanup state) in
   let rec try_request () =
     try
       GapiConversation.with_session
@@ -97,9 +96,7 @@ let do_request
   in
     try
       try_request ();
-      cleanup ()
     with e ->
-      cleanup ();
       raise e
 
 let test_request


### PR DESCRIPTION
I made a horrible error by attempting to return a Lwt promise from a callback.  Unfortunately, the curl session disappears before the promise can be resolved, because it's cleaned up immediately after the callback returns.  To fix this, we can let the OCaml garbage collector clean up the session for us by registering a finalizer, instead of explicitly cleaning it up after the callback returns.  Now it works with Lwt.

The unit tests still pass, so I don't think I broke anything. :)