### PR TITLE
Document use of media_download parameter

### DIFF
--- a/src/gapi/gapiDriveV2Service.mli
+++ b/src/gapi/gapiDriveV2Service.mli
@@ -483,7 +483,7 @@ sig
   
   (** Exports a Google Doc as the requested MIME type to the location specified by [media_download]. Please note that the exported content is limited to 10MB.
 
-    @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v3/"]).
+    @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v2/"]).
     @param std_params Optional standard parameters.
     @param media_download Location where the exported file will be saved.
     @param fileId The ID of the file.

--- a/src/gapi/gapiDriveV2Service.mli
+++ b/src/gapi/gapiDriveV2Service.mli
@@ -481,10 +481,11 @@ sig
     GapiConversation.Session.t ->
     unit * GapiConversation.Session.t
   
-  (** Exports a Google Doc to the requested MIME type and returns the exported content.
-    
-    @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v2/"]).
+  (** Exports a Google Doc as the requested MIME type to the location specified by [media_download]. Please note that the exported content is limited to 10MB.
+
+    @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v3/"]).
     @param std_params Optional standard parameters.
+    @param media_download Location where the exported file will be saved.
     @param fileId The ID of the file.
     @param mimeType The MIME type of the format requested for this export.
     *)
@@ -513,10 +514,14 @@ sig
     GapiDriveV2Model.GeneratedIds.t * GapiConversation.Session.t
   
   (** Gets a file's metadata by ID.
-    
+
+    If [std_params] includes setting [alt = "media"], the file content is
+    downloaded as per [media_download].
+
     @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v2/"]).
     @param etag Optional ETag.
     @param std_params Optional standard parameters.
+    @param media_download Location where downloaded data will be saved.
     @param acknowledgeAbuse Whether the user is acknowledging the risk of downloading known malware or other abusive files.
     @param updateViewedDate Deprecated: Use files.update with modifiedDateBehavior=noChange, updateViewedDate=true and an empty request body.
     @param projection This parameter is deprecated and has no function.
@@ -714,6 +719,7 @@ sig
     
     @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v2/"]).
     @param std_params Optional standard parameters.
+    @param media_download Location where downloaded data will be saved.
     @param acknowledgeAbuse Whether the user is acknowledging the risk of downloading known malware or other abusive files.
     @param updateViewedDate Deprecated: Use files.update with modifiedDateBehavior=noChange, updateViewedDate=true and an empty request body.
     @param projection This parameter is deprecated and has no function.
@@ -1036,6 +1042,7 @@ sig
     @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v2/"]).
     @param etag Optional ETag.
     @param std_params Optional standard parameters.
+    @param media_download Location where downloaded data will be saved.
     @param revision The revision of the Realtime API data model to export. Revisions start at 1 (the initial empty data model) and are incremented with each change. If this parameter is excluded, the most recent data model will be returned.
     @param fileId The ID of the file that the Realtime API data model is associated with.
     *)

--- a/src/gapi/gapiDriveV3Service.mli
+++ b/src/gapi/gapiDriveV3Service.mli
@@ -471,10 +471,11 @@ sig
     GapiConversation.Session.t ->
     unit * GapiConversation.Session.t
   
-  (** Exports a Google Doc to the requested MIME type and returns the exported content. Please note that the exported content is limited to 10MB.
-    
+  (** Exports a Google Doc as the requested MIME type to the location specified by [media_download]. Please note that the exported content is limited to 10MB.
+
     @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v3/"]).
     @param std_params Optional standard parameters.
+    @param media_download Location where the exported file will be saved.
     @param fileId The ID of the file.
     @param mimeType The MIME type of the format requested for this export.
     *)
@@ -503,10 +504,14 @@ sig
     GapiDriveV3Model.GeneratedIds.t * GapiConversation.Session.t
   
   (** Gets a file's metadata or content by ID.
+
+    If [std_params] includes setting [alt = "media"], the file content is
+    downloaded as per [media_download].
     
     @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v3/"]).
     @param etag Optional ETag.
     @param std_params Optional standard parameters.
+    @param media_download Location where downloaded data will be saved.
     @param acknowledgeAbuse Whether the user is acknowledging the risk of downloading known malware or other abusive files. This is only applicable when alt=media.
     @param supportsAllDrives Deprecated - Whether the requesting application supports both My Drives and shared drives. This parameter will only be effective until June 1, 2020. Afterwards all applications are assumed to support shared drives.
     @param supportsTeamDrives Deprecated use supportsAllDrives instead.
@@ -596,6 +601,7 @@ sig
     
     @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v3/"]).
     @param std_params Optional standard parameters.
+    @param media_download Location where downloaded data will be saved.
     @param acknowledgeAbuse Whether the user is acknowledging the risk of downloading known malware or other abusive files. This is only applicable when alt=media.
     @param supportsAllDrives Deprecated - Whether the requesting application supports both My Drives and shared drives. This parameter will only be effective until June 1, 2020. Afterwards all applications are assumed to support shared drives.
     @param supportsTeamDrives Deprecated use supportsAllDrives instead.
@@ -867,6 +873,7 @@ sig
     @param base_url Service endpoint base URL (defaults to ["https://www.googleapis.com/drive/v3/"]).
     @param etag Optional ETag.
     @param std_params Optional standard parameters.
+    @param media_download Location where the downloaded data will be saved.
     @param acknowledgeAbuse Whether the user is acknowledging the risk of downloading known malware or other abusive files. This is only applicable when alt=media.
     @param fileId The ID of the file.
     @param revisionId The ID of the revision.


### PR DESCRIPTION
It took me some time looking at the source and example usage in ocamlfuse to figure out how to actually obtain the data downloaded by `export` and `get`. I think these documentation changes would have helped guide me quicker.

Let me know if you'd like me to rephrase anything!