### PR TITLE
Yojson 2.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You will need the following libraries:
 * [Ocamlnet][] >= 4.1.4
 * [Ocurl][] >= 0.5.3
 * [Cryptokit][] >= 1.3.14
-* [Yojson][] >= 1.0.2
+* [Yojson][] >= 1.6.0
 * [Xmlm][] >= 1.0.2
 * [OUnit][] >= 1.1.0 (to build and run the tests, optional)
 
@@ -53,7 +53,7 @@ This library was developed and tested on Ubuntu LTS (64-bit).
 [Ocamlnet]: http://projects.camlcity.org/projects/ocamlnet.html
 [Ocurl]: http://ygrek.org.ua/p/ocurl/
 [Cryptokit]: https://github.com/xavierleroy/cryptokit
-[Yojson]: http://mjambon.com/yojson.html
+[Yojson]: https://github.com/ocaml-community/yojson
 [Xmlm]: http://erratique.ch/software/xmlm
 [OUnit]: http://ounit.forge.ocamlcore.org/
 

--- a/gapi-ocaml.opam
+++ b/gapi-ocaml.opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlnet" {>= "4.1.4"}
   "ocurl"
   "ounit2" {with-test}
-  "yojson"
+  "yojson" {>= "1.6.0"}
 ]
 synopsis: "A simple OCaml client for Google Services"
 description: """

--- a/src/gapi/dune
+++ b/src/gapi/dune
@@ -3,5 +3,5 @@
  (public_name gapi-ocaml)
  (wrapped false)
  (libraries netsys threads netstring curl str cryptokit yojson)
- (flags (:standard -w -3-23-27-32-33))
+ (flags (:standard -w -23-27-32-33))
  (synopsis "Google APIs client library"))

--- a/src/gapi/gapiCore.ml
+++ b/src/gapi/gapiCore.ml
@@ -105,7 +105,7 @@ module Header = struct
     if String.contains full_header ':' then
       let key, v = GapiUtils.divide_string full_header ':' in
       let value = GapiUtils.strip_string v in
-      let lowercase_key = String.lowercase key in
+      let lowercase_key = String.lowercase key [@warning "-3"] in
       match lowercase_key with
       | "content-type" -> ContentType value
       | "location" -> Location value

--- a/src/gapi/gapiJson.ml
+++ b/src/gapi/gapiJson.ml
@@ -14,7 +14,7 @@ type json_metadata = { name : string; data_type : json_data_type }
 let metadata_description { name = n; data_type = dt } =
   Printf.sprintf "name=%s data_type=%s" n (json_data_type_to_string dt)
 
-type json_data_model = (json_metadata, Yojson.Safe.json) AnnotatedTree.t
+type json_data_model = (json_metadata, Yojson.Safe.t) AnnotatedTree.t
 
 let unexpected r e x =
   ( match e with

--- a/src/gapi/gapiJson.mli
+++ b/src/gapi/gapiJson.mli
@@ -10,12 +10,12 @@ type json_metadata = { name : string; data_type : json_data_type }
 val metadata_description : json_metadata -> string
 
 type json_data_model =
-  (json_metadata, Yojson.Safe.json) GapiCore.AnnotatedTree.t
+  (json_metadata, Yojson.Safe.t) GapiCore.AnnotatedTree.t
 
 val unexpected : string -> json_data_model -> 'a -> 'a
 
 val render_value :
-  string -> Yojson.Safe.json -> Yojson.Safe.json -> json_data_model list
+  string -> Yojson.Safe.t -> Yojson.Safe.t -> json_data_model list
 
 val render_string_value :
   ?default:string -> string -> string -> json_data_model list
@@ -78,9 +78,9 @@ val parse_string_element : string -> json_data_model -> string
 val parse_dictionary_entry :
   string * string -> json_data_model -> string * string
 
-val json_to_data_model : Yojson.Safe.json -> json_data_model
+val json_to_data_model : Yojson.Safe.t -> json_data_model
 
-val data_model_to_json : json_data_model -> Yojson.Safe.json
+val data_model_to_json : json_data_model -> Yojson.Safe.t
 
 val parse_json_response :
   (json_data_model -> 'a) -> GapiPipe.OcamlnetPipe.t -> 'a

--- a/src/gapi/gapiMediaResource.ml
+++ b/src/gapi/gapiMediaResource.ml
@@ -147,7 +147,7 @@ let get_resource_length = function
 
 let get_content_type filename =
   let extension =
-    try GapiUtils.string_after_char '.' filename |> String.lowercase
+    try GapiUtils.string_after_char '.' filename |> String.lowercase [@warning "-3"]
     with Not_found -> ""
   in
   match extension with

--- a/src/gapi/gapiServiceAccountCredentials.mli
+++ b/src/gapi/gapiServiceAccountCredentials.mli
@@ -33,7 +33,7 @@ val client_x509_cert_url : (t, string) GapiLens.t
 
 val to_data_model : t -> GapiJson.json_data_model
 
-val to_json : t -> Yojson.Safe.json
+val to_json : t -> Yojson.Safe.t
 
 val parse_json : string -> t
 


### PR DESCRIPTION
This PR changes the code to use non-deprecated Yojson types that will continue to work after the release of 2.0. It also removes the general silencing of deprecation warnings and only adds them in the specific places where it is required for compatibility with OCaml 4.02.