### PR TITLE
fix warnings in netstring and netsys

### DIFF
--- a/src/netstring/dune
+++ b/src/netstring/dune
@@ -3,7 +3,7 @@
  (public_name gapi-ocaml.netstring-local)
  (wrapped false)
  (libraries gapi-ocaml.netsys-local camlp-streams str)
- (flags (:standard -w -6-7-8-27-32-33-34-35-36-37-39-50-52))
+ (flags (:standard -w -6-7-8-27-32-33-34-35-36-37-39-50-52-69))
  (preprocess
    (action
      (run %{bin:cppo} -V OCAML:%{ocaml_version} -D HAVE_BYTES -D HAVE_O_SHARE_DELETE -D HAVE_O_CLOEXEC -D HAVE_O_KEEPEXEC -D "DEPRECATED(arg) [@@deprecated arg] (** @deprecated arg *)" -D "STRING_COPY (fun s -> s)" -D "STRING_LOWERCASE String.lowercase_ascii" -D "STRING_UPPERCASE String.uppercase_ascii" -D "STRING_CAPITALIZE String.capitalize_ascii" -D "CHAR_LOWERCASE Char.lowercase_ascii" -D "CHAR_UPPERCASE Char.uppercase_ascii" -D HAVE_EXTENSIBLE_VARIANTS -D HAVE_UNIX_MAP_FILE -D "NOALLOC [@@noalloc]" %{input-file})))

--- a/src/netsys/dune
+++ b/src/netsys/dune
@@ -4,7 +4,7 @@
  (wrapped false)
  (libraries unix)
  (foreign_stubs (language c) (names netsys_c netsys_c_clock netsys_c_event netsys_c_fadvise netsys_c_fallocate netsys_c_gprof netsys_c_htab netsys_c_ioprio netsys_c_ip6 netsys_c_locale netsys_c_mem netsys_c_multicast netsys_c_poll netsys_c_queue netsys_c_sem netsys_c_shm netsys_c_spawn netsys_c_subprocess netsys_c_syslog netsys_c_win32 netsys_c_xdr))
- (flags (:standard -w -6-7-8-27-32-33-34-35-36-37-39-50-52-53))
+ (flags (:standard -w -6-7-8-27-32-33-34-35-36-37-39-50-52-53-69))
  (preprocess
    (action
      (run %{bin:cppo} -V OCAML:%{ocaml_version} -D HAVE_BYTES -D HAVE_O_SHARE_DELETE -D HAVE_O_CLOEXEC -D HAVE_O_KEEPEXEC -D "DEPRECATED(arg) [@@deprecated arg] (** @deprecated arg *)" -D "STRING_COPY (fun s -> s)" -D "STRING_LOWERCASE String.lowercase_ascii" -D "STRING_UPPERCASE String.uppercase_ascii" -D "STRING_CAPITALIZE String.capitalize_ascii" -D "CHAR_LOWERCASE Char.lowercase_ascii" -D "CHAR_UPPERCASE Char.uppercase_ascii" -D HAVE_EXTENSIBLE_VARIANTS -D HAVE_UNIX_MAP_FILE -D "NOALLOC [@@noalloc]" %{input-file})))


### PR DESCRIPTION
These warnings appear in a more recent OCaml so we silence them.