### PR TITLE
Fix build in OCaml 5.4

### DIFF
--- a/src/netsys/netsys_c.h
+++ b/src/netsys/netsys_c.h
@@ -219,7 +219,7 @@ union sock_addr_union {
 /* bigarrays                                                          */
 /**********************************************************************/
 
-extern int caml_ba_element_size[];
+// extern int caml_ba_element_size[];
 
 
 #endif


### PR DESCRIPTION
There is a duplicated declaration in 5.4's `caml/bigarray.h` which has different const-ness specified, causing aborted compilation.
This PR removes the conflicting declaration.